### PR TITLE
fix problem with unwanted macro disabling during multiple tests run

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -54,7 +54,9 @@ object MacMemoBuild extends Build {
         "org.scala-lang" % "scala-reflect" % ScalaVersion,
         "com.google.guava" % "guava" % "13.0.1",
         "com.google.code.findbugs" % "jsr305" % "1.3.+",
-        "org.scalatest" % "scalatest_2.11" % "2.2.0" % "test"))
+        "org.scalatest" % "scalatest_2.11" % "2.2.0" % "test"),
+      parallelExecution in Test := false
+    )
   )
 
   // Enabling debug project-wide. Can't find a better way to pass options to scalac.


### PR DESCRIPTION
I've encountered some random test fails on my wip branch after I rebased it to 92920d846818fdb3d43973215832414cf85486d6. 
The problem laid out in altering global System.property and tests' parallel execution.
This PR disables parallel execution for ScalaTest.
